### PR TITLE
Feat: add graphics widget

### DIFF
--- a/src/elements/controls/graphics.ts
+++ b/src/elements/controls/graphics.ts
@@ -1,0 +1,41 @@
+import { BuildOutput } from "@src/windows/buildOutput";
+import { ParentControl } from "@src/windows/parentControl";
+import { WidgetCreator } from "@src/windows/widgets/widgetCreator";
+import { ElementParams } from "../elementParams";
+import { AbsolutePosition } from "../layouts/absolute/absolutePosition";
+import { FlexiblePosition } from "../layouts/flexible/flexiblePosition";
+import { Control } from "./control";
+
+/**
+ * The parameters for configuring the custom graphics drawing widget.
+ */
+export interface GraphicsParams extends ElementParams {
+    /**
+     * Use for drawing custom graphics. See {@link GraphicsContext} for more information.
+     * @default undefined
+     */
+    onDraw?: (g: GraphicsContext) => void;
+}
+
+/**
+ * Create a custom widget for drawing.
+ */
+export function graphics(params: GraphicsParams & FlexiblePosition): WidgetCreator<FlexiblePosition>;
+export function graphics(params: GraphicsParams & AbsolutePosition): WidgetCreator<AbsolutePosition>;
+export function graphics<I, P>(params: GraphicsParams & I): WidgetCreator<I, P> {
+    return (parent, output) => new GraphicsControls<I, P>(parent, output, params);
+}
+
+/**
+ * A controller class for a graphics drawing widget.
+ */
+export class GraphicsControls<I, P> extends Control<CustomDesc, I, P> implements CustomDesc, GraphicsParams {
+    onDraw?: ((g: GraphicsContext) => void) | undefined;
+
+    constructor(parent: ParentControl<I, P>, output: BuildOutput, params: GraphicsParams & I) {
+        super("custom", parent, output, params);
+
+        const binder = output.binder;
+        binder.add(this, "onDraw", (this, params.onDraw));
+    }
+}

--- a/src/elements/controls/graphics.ts
+++ b/src/elements/controls/graphics.ts
@@ -9,7 +9,8 @@ import { Control } from "./control";
 /**
  * The parameters for configuring the custom graphics drawing widget.
  */
-export interface GraphicsParams extends ElementParams {
+export interface GraphicsParams extends ElementParams
+{
     /**
      * Use for drawing custom graphics. See {@link GraphicsContext} for more information.
      * @default undefined
@@ -22,20 +23,21 @@ export interface GraphicsParams extends ElementParams {
  */
 export function graphics(params: GraphicsParams & FlexiblePosition): WidgetCreator<FlexiblePosition>;
 export function graphics(params: GraphicsParams & AbsolutePosition): WidgetCreator<AbsolutePosition>;
-export function graphics<I, P>(params: GraphicsParams & I): WidgetCreator<I, P> {
+export function graphics<I, P>(params: GraphicsParams & I): WidgetCreator<I, P>
+{
     return (parent, output) => new GraphicsControls<I, P>(parent, output, params);
 }
 
 /**
  * A controller class for a graphics drawing widget.
  */
-export class GraphicsControls<I, P> extends Control<CustomDesc, I, P> implements CustomDesc, GraphicsParams {
-    onDraw?: ((g: GraphicsContext) => void) | undefined;
+export class GraphicsControls<I, P> extends Control<CustomDesc, I, P> implements CustomDesc, GraphicsParams
+{
+    onDraw?: ((g: GraphicsContext) => void);
 
-    constructor(parent: ParentControl<I, P>, output: BuildOutput, params: GraphicsParams & I) {
+    constructor(parent: ParentControl<I, P>, output: BuildOutput, params: GraphicsParams & I)
+    {
         super("custom", parent, output, params);
-
-        const binder = output.binder;
-        binder.add(this, "onDraw", (this, params.onDraw));
+        this.onDraw = params.onDraw;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export { dropdown, DropdownParams, DropdownDisableMode } from "./elements/contro
 export { dropdownButton, DropdownButtonParams, DropdownButtonAction } from "./elements/controls/dropdownButton";
 export { dropdownSpinner, DropdownSpinnerParams } from "./elements/controls/dropdownSpinner";
 export { flexible, horizontal, vertical, FlexibleLayoutParams, FlexibleLayoutContainer } from "./elements/layouts/flexible/flexible";
+export { graphics, GraphicsParams } from "./elements/controls/graphics";
 export { groupbox, GroupBoxParams } from "./elements/controls/groupbox";
 export { label, LabelParams } from "./elements/controls/label";
 export { listview, ListViewParams, ListViewColumnParams } from "./elements/controls/listview";


### PR DESCRIPTION
Addresses issue #33.

This PR mimics the style and structure of the other widgets. I've tested locally and am getting expected graphics drawing behavior. 

Nice To Haves:
* I was unable to get a symlink working to add a graphics widget in the AllWidgets example, so I left it alone for now.
* I didn't create any tests since I wasn't sure how to verify onDraw working as intended. I can copy/paste the boilerplate if desired.

Example use:
```ts
import * as flex from "openrct2-flexui";
export function startup() {
  if (typeof ui !== "undefined") {
    initialize();
    const menuItemName = "Drawing";
    ui.registerMenuItem(menuItemName, openWindow);
  }
}

let window: flex.WindowTemplate;
let isWindowOpen = false;

export function initialize() {
    window = flex.window({
        title: "Draw",
        width: 300,
        height: 250,
        position: "center",
        colours: [flex.Colour.LightBlue, flex.Colour.White],
        onOpen: () => (isWindowOpen = true),
        onClose: () => (isWindowOpen = false),
        content: [
            flex.graphics({
                height: 200,
                onDraw: function (g: GraphicsContext) {
                    for (let i = 0; i < 16; i++) {
                        for (let j = 0; j < 15; j++) {
                            g.colour = i + j * 16 + 2;
                            g.fill = i + j * 16 + 2;
                            g.rect(i * 10, j * 10, 10, 10);
                        }
                    }
                },
            })
        ],
    });
}

export function openWindow() {
    if (isWindowOpen) {
        window.focus();
    } else {
        window.open();
    }
}
```

This code generates this window: 
<img width="468" alt="image" src="https://github.com/Basssiiie/OpenRCT2-FlexUI/assets/12832906/fd9ce70c-c29a-4058-b8a8-d06d1df765e8">
